### PR TITLE
Add web frontend and backend API for deck builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -305,3 +305,7 @@ TSWLatexianTemp*
 # Uncomment the next line to have this generated file ignored.
 #*Notes.bib
 /__pycache__
+node_modules/
+frontend/dist/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,18 +1,70 @@
 # 万智牌锁牌名录
 
-本项目是万智牌锁牌名录的源代码，包含了编写本书用到的所有图片和代码（LaTeX用于生成pdf文档，python用于爬取锁牌信息）。
+本项目包含《万智牌锁牌名录》的生成工具链以及全新的 Web 前后端，用于在浏览器中检索、筛选并构建锁牌牌本。
 
-本项目中文件有以下用途：
+## 目录结构概览
 
-* figure：包含生成pdf文档用到的图片
-* Images：包含所有锁牌图片，尽量保持了高清和中文
-* 锁牌.md：没啥用的玩意，我之后会删掉
-* AllThatStax.tex：用于生成pdf文档用到的LaTeX主文件
-* config.json：用于配置python中会用到的文件的位置信息
-* genarate_latex.py：包含从表格中提取信息，并生成可使用在LaTeX中的文本的方法
-* get_cards_information.py：包含从srcyfall API获取卡牌信息，并存储于表格中的方法
-* latex.txt：生成出的可用于LaTeX中的文本文件
-* list.txt：用于向scryfall API获取卡牌信息的名称，采用MTGO格式
-* main.py：主代码
-* multiface_sheet.xlsx：包含双面牌（和翻转牌）的信息
-* sheet.xlsx：包含单面牌的信息
+- `AllThatStax.cls` / `AllThatStax.tex`：LaTeX 文档类与主文件，用于生成书籍 PDF。
+- `Figures/`、`Images/`、`Symbols/`：书籍所需的插图、卡图与法术力符号。
+- `card_information_sheet.xlsx`：整理后的卡牌数据源，`Sheet`/`Multiface Sheet` 分别存放单面牌与多面牌。
+- `config.json`：配置文件，定义图像、表格、锁类型映射等路径。
+- `get_cards_information.py`、`localization.py`、`genarate_latex_text.py`、`run_latex.py`、`main.py`：原有的 Python 数据抓取、文本生成与编译脚本。
+- `backend/`：基于 FastAPI 的数据 API，提供卡牌数据与元信息，并托管图片、法术力图标静态资源。
+- `frontend/`：基于 Vite + React + TypeScript 的前端项目，包含卡牌表格、筛选器以及可视化牌本构建界面。
+
+## 后端（FastAPI）
+
+后端会从 `card_information_sheet.xlsx` 中读取卡牌数据，统一输出给前端使用，并挂载图片及法术力符号静态目录。
+
+### 快速启动
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn backend.app:app --reload
+```
+
+接口默认监听在 `http://127.0.0.1:8000`，关键端点：
+
+- `GET /cards`：返回所有单面牌与多面牌的结构化数据。
+- `GET /cards/{card_id}`：按 ID 获取指定卡牌详情。
+- `GET /metadata`：返回锁类型映射与牌类型排序信息。
+- `GET /health`：健康检查。
+
+静态资源：
+
+- `/images/*`：卡图原图。
+- `/symbols/*`：法术力符号 SVG。
+
+## 前端（Vite + React）
+
+前端提供卡牌浏览与牌本构建界面，支持按名称/描述搜索、按锁类型和牌类型筛选、展示法术力曲线与锁类型分布等功能。
+
+### 本地开发
+
+```bash
+cd frontend
+npm install
+# 配置后端地址（如需跨域）
+cp .env.example .env
+npm run dev
+```
+
+默认情况下，Vite 会通过代理将 `/cards`、`/metadata`、`/images`、`/symbols` 请求转发到 `.env` 中的 `VITE_API_BASE_URL`（默认为 `http://localhost:8000`）。
+
+### 生产构建
+
+```bash
+npm run build
+```
+
+构建产物位于 `frontend/dist/`。
+
+## 牌本工作流
+
+1. 使用后端脚本更新 `card_information_sheet.xlsx` 与本地图片资源。
+2. 启动 FastAPI 服务，通过 `/cards` 和 `/metadata` 获取最新数据。
+3. 启动前端，浏览卡牌表格并将卡牌加入右侧牌本面板。
+4. 前端自动按法术力曲线与牌类型分区展示卡牌，便于整理、导出和继续在 LaTeX 流程中使用。
+
+欢迎根据需要扩展 API、添加导出能力或集成现有 LaTeX 生成流程。

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for AllThatStax web API."""

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import json
+import re
+import threading
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Iterable, List, Literal, Optional
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+from starlette.responses import JSONResponse
+from starlette.status import HTTP_404_NOT_FOUND
+
+try:
+    from openpyxl import load_workbook
+except ImportError as exc:  # pragma: no cover - handled during runtime only
+    raise RuntimeError("openpyxl is required to run the backend") from exc
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+CONFIG_PATH = BASE_DIR / "config.json"
+
+LEGALITY_KEYS: List[str] = [
+    "standard",
+    "alchemy",
+    "pioneer",
+    "explorer",
+    "modern",
+    "historic",
+    "legacy",
+    "pauper",
+    "vintage",
+    "timeless",
+    "commander",
+    "duel",
+]
+
+CARD_TYPE_ORDER = ["生物", "神器", "结界", "其他"]
+
+_mana_pattern = re.compile(r"\{([^}]+)\}")
+_cache_lock = threading.Lock()
+_cached_payload: Optional[Dict[str, object]] = None
+_cached_mtime: Optional[float] = None
+
+
+def _load_config() -> Dict[str, object]:
+    if not CONFIG_PATH.exists():
+        raise FileNotFoundError(f"Config file not found at {CONFIG_PATH}")
+    with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+CONFIG = _load_config()
+
+
+class CardFace(BaseModel):
+    englishName: str
+    chineseName: str
+    image: str
+    manaCost: List[str]
+    cardType: str
+    description: str
+
+
+class StaxType(BaseModel):
+    key: str
+    label: str
+
+
+class Card(BaseModel):
+    id: str
+    kind: Literal["single", "multiface"]
+    faces: List[CardFace]
+    staxType: Optional[StaxType]
+    isRestricted: bool
+    legalities: Dict[str, str]
+    manaValue: int
+    sortCardType: str
+
+
+class Metadata(BaseModel):
+    staxTypes: List[StaxType]
+    cardTypeOrder: List[str]
+
+
+app = FastAPI(title="AllThatStax API", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+images_dir = BASE_DIR / str(CONFIG["image_folder_name"])
+symbols_dir = BASE_DIR / "Symbols"
+
+if images_dir.exists():
+    app.mount("/images", StaticFiles(directory=images_dir), name="images")
+
+if symbols_dir.exists():
+    app.mount("/symbols", StaticFiles(directory=symbols_dir), name="symbols")
+
+
+def _normalise_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    text = str(value).strip().lower()
+    return text in {"true", "1", "yes", "y", "是", "真"}
+
+
+def _parse_mana_cost(raw_cost: Optional[str]) -> List[str]:
+    if raw_cost is None:
+        return []
+    if "{" not in raw_cost:
+        text = raw_cost.strip()
+        return [text] if text else []
+    return [token.upper() for token in _mana_pattern.findall(raw_cost)]
+
+
+def _build_face(prefix: str, row: List[object]) -> CardFace:
+    english = str(row[0]).strip()
+    chinese = str(row[1]).strip()
+    image_value = row[2] if len(row) > 2 else None
+    image_name = str(image_value).strip() if image_value else ""
+    image_path = f"/images/{image_name}" if image_name else ""
+    mana_cost_raw = row[3] if len(row) > 3 else None
+    card_type = str(row[4]).strip()
+    description_raw = row[5] if len(row) > 5 else ""
+    description = str(description_raw or "").strip()
+    return CardFace(
+        englishName=english,
+        chineseName=chinese,
+        image=image_path,
+        manaCost=_parse_mana_cost(mana_cost_raw if isinstance(mana_cost_raw, str) else str(mana_cost_raw) if mana_cost_raw is not None else None),
+        cardType=card_type,
+        description=description,
+    )
+
+
+def _read_sheet_rows(sheet) -> Iterable[List[object]]:
+    for row in sheet.iter_rows(values_only=True):
+        yield list(row)
+
+
+def _load_cards_payload(force: bool = False) -> Dict[str, object]:
+    global _cached_payload, _cached_mtime
+
+    sheet_path = BASE_DIR / str(CONFIG["sheet_file_name"])
+    if not sheet_path.exists():
+        raise FileNotFoundError(f"Sheet file not found at {sheet_path}")
+
+    mtime = sheet_path.stat().st_mtime
+    with _cache_lock:
+        if not force and _cached_payload is not None and _cached_mtime == mtime:
+            return _cached_payload
+
+        workbook = load_workbook(sheet_path, data_only=True)
+
+        single_sheet = workbook[str(CONFIG["sheet_name"])]
+        multi_sheet = workbook[str(CONFIG["multiface_sheet_name"])]
+
+        cards: List[Card] = []
+
+        single_rows = list(_read_sheet_rows(single_sheet))
+        multi_rows = list(_read_sheet_rows(multi_sheet))
+
+        if single_rows:
+            single_rows = single_rows[1:]  # remove header
+        if multi_rows:
+            multi_rows = multi_rows[1:]
+
+        for row in single_rows:
+            if not any(row):
+                continue
+            face = _build_face("", row)
+            legality_values = {key: str(row[idx]).strip() if row[idx] is not None else "unknown" for idx, key in enumerate(LEGALITY_KEYS, start=8)}
+            card = Card(
+                id=f"single-{face.englishName}",
+                kind="single",
+                faces=[face],
+                staxType=_build_stax_type(row[6]),
+                isRestricted=_normalise_bool(row[7]),
+                legalities=legality_values,
+                manaValue=int(row[20]) if row[20] is not None else 0,
+                sortCardType=str(row[21] or "其他"),
+            )
+            cards.append(card)
+
+        for row in multi_rows:
+            if not any(row):
+                continue
+            front = _build_face("front_", row[0:6])
+            back = _build_face("back_", row[6:12])
+            legality_values = {key: str(row[idx]).strip() if row[idx] is not None else "unknown" for idx, key in enumerate(LEGALITY_KEYS, start=14)}
+            card = Card(
+                id=f"multiface-{front.englishName}",
+                kind="multiface",
+                faces=[front, back],
+                staxType=_build_stax_type(row[12]),
+                isRestricted=_normalise_bool(row[13]),
+                legalities=legality_values,
+                manaValue=int(row[26]) if row[26] is not None else 0,
+                sortCardType=str(row[27] or "其他"),
+            )
+            cards.append(card)
+
+        stax_types = _build_stax_types()
+
+        payload = {
+            "cards": cards,
+            "metadata": {
+                "staxTypes": stax_types,
+                "cardTypeOrder": CARD_TYPE_ORDER,
+            },
+        }
+
+        _cached_payload = payload
+        _cached_mtime = mtime
+        return payload
+
+
+def _build_stax_type(value: object) -> Optional[StaxType]:
+    if value is None:
+        return None
+    english_key = str(value).strip()
+    if not english_key:
+        return None
+    chinese = str(CONFIG.get("stax_type", {}).get(english_key, english_key))
+    return StaxType(key=english_key, label=chinese)
+
+
+@lru_cache()
+def _build_stax_types() -> List[StaxType]:
+    mapping = CONFIG.get("stax_type", {})
+    stax_types = [StaxType(key=key, label=str(label)) for key, label in mapping.items()]
+    stax_types.sort(key=lambda item: item.label)
+    return stax_types
+
+
+@app.get("/health")
+def health_check() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/cards", response_model=List[Card])
+def list_cards(force_reload: bool = Query(False, alias="reload")) -> List[Card]:
+    payload = _load_cards_payload(force=force_reload)
+    return payload["cards"]  # type: ignore[return-value]
+
+
+@app.get("/metadata", response_model=Metadata)
+def get_metadata() -> Metadata:
+    payload = _load_cards_payload()
+    metadata = payload["metadata"]
+    return Metadata(**metadata)  # type: ignore[arg-type]
+
+
+@app.get("/cards/{card_id}", response_model=Card)
+def get_card(card_id: str) -> Card:
+    payload = _load_cards_payload()
+    cards: Iterable[Card] = payload["cards"]  # type: ignore[assignment]
+    for card in cards:
+        if card.id == card_id:
+            return card
+    raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail="Card not found")
+
+
+@app.exception_handler(FileNotFoundError)
+async def _handle_missing_file(_: "FileNotFoundError") -> JSONResponse:
+    return JSONResponse(status_code=500, content={"detail": "Required data file is missing."})

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+openpyxl==3.1.2

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# 后端 API 地址，例如 http://localhost:8000
+VITE_API_BASE_URL=

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>All That Stax Builder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "all-that-stax-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.24",
+    "@types/react-dom": "^18.2.11",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,96 @@
+.app {
+  padding: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app--loading,
+.app--error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  font-size: 1.2rem;
+}
+
+.app__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-end;
+}
+
+.app__header h1 {
+  margin: 0;
+  font-size: 2rem;
+  color: #111827;
+}
+
+.app__header p {
+  margin: 0.5rem 0 0;
+  color: #475569;
+}
+
+.app__filters {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.app__filters input,
+.app__filters select {
+  padding: 0.55rem 0.8rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 0.75rem;
+  font-size: 0.95rem;
+  background: #fff;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+}
+
+.app__content {
+  display: grid;
+  grid-template-columns: 3fr 2fr;
+  gap: 1.5rem;
+}
+
+.app__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.app__panel h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: #1e293b;
+}
+
+@media (max-width: 1200px) {
+  .app__content {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .app {
+    padding: 1.25rem;
+  }
+
+  .app__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .app__filters {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .app__filters input,
+  .app__filters select {
+    flex: 1 1 200px;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useState } from "react";
+import { CardTable } from "./components/CardTable";
+import { DeckBoard } from "./components/DeckBoard";
+import { fetchCards, fetchMetadata } from "./api";
+import { CardData, DeckCounts, Metadata } from "./types";
+import "./App.css";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+
+function normaliseQuery(value: string) {
+  return value.trim().toLowerCase();
+}
+
+export default function App() {
+  const [cards, setCards] = useState<CardData[]>([]);
+  const [metadata, setMetadata] = useState<Metadata | null>(null);
+  const [deckCounts, setDeckCounts] = useState<DeckCounts>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [selectedStaxType, setSelectedStaxType] = useState("all");
+  const [selectedCardType, setSelectedCardType] = useState("all");
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [cardData, meta] = await Promise.all([
+          fetchCards(),
+          fetchMetadata(),
+        ]);
+        setCards(cardData);
+        setMetadata(meta);
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "未知错误");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    load();
+  }, []);
+
+  const filteredCards = useMemo(() => {
+    const q = normaliseQuery(query);
+    return cards.filter((card) => {
+      const primaryFace = card.faces[0];
+      const matchesQuery =
+        !q ||
+        primaryFace.chineseName.toLowerCase().includes(q) ||
+        primaryFace.englishName.toLowerCase().includes(q) ||
+        primaryFace.description.toLowerCase().includes(q);
+
+      const matchesStax =
+        selectedStaxType === "all" || card.staxType?.key === selectedStaxType;
+
+      const matchesType =
+        selectedCardType === "all" || card.sortCardType === selectedCardType;
+
+      return matchesQuery && matchesStax && matchesType;
+    });
+  }, [cards, query, selectedStaxType, selectedCardType]);
+
+  const handleAddCard = (card: CardData) => {
+    setDeckCounts((prev) => ({
+      ...prev,
+      [card.id]: (prev[card.id] ?? 0) + 1,
+    }));
+  };
+
+  const handleRemoveCard = (cardId: string) => {
+    setDeckCounts((prev) => {
+      const current = prev[cardId] ?? 0;
+      if (current <= 1) {
+        const { [cardId]: _removed, ...rest } = prev;
+        return rest;
+      }
+      return {
+        ...prev,
+        [cardId]: current - 1,
+      };
+    });
+  };
+
+  const handleClearDeck = () => setDeckCounts({});
+
+  if (loading) {
+    return <div className="app app--loading">正在加载卡牌数据…</div>;
+  }
+
+  if (error) {
+    return <div className="app app--error">加载失败：{error}</div>;
+  }
+
+  return (
+    <div className="app">
+      <header className="app__header">
+        <div>
+          <h1>锁牌名录牌本构建器</h1>
+          <p>浏览、筛选卡牌并构建你的锁牌牌本。</p>
+        </div>
+        <div className="app__filters">
+          <input
+            type="search"
+            placeholder="搜索中文名、英文名或描述…"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <select
+            value={selectedStaxType}
+            onChange={(event) => setSelectedStaxType(event.target.value)}
+          >
+            <option value="all">全部锁类型</option>
+            {metadata?.staxTypes.map((type) => (
+              <option key={type.key} value={type.key}>
+                {type.label}
+              </option>
+            ))}
+          </select>
+          <select
+            value={selectedCardType}
+            onChange={(event) => setSelectedCardType(event.target.value)}
+          >
+            <option value="all">全部牌类型</option>
+            {[...(metadata?.cardTypeOrder ?? [])]
+              .concat(
+                Array.from(
+                  new Set(cards.map((card) => card.sortCardType || "其他"))
+                ).filter(
+                  (type) => !(metadata?.cardTypeOrder ?? []).includes(type)
+                )
+              )
+              .map((type) => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
+              ))}
+          </select>
+        </div>
+      </header>
+
+      <main className="app__content">
+        <section className="app__panel app__panel--table">
+          <h2>卡牌列表</h2>
+          <CardTable cards={filteredCards} onAdd={handleAddCard} apiBase={API_BASE} />
+        </section>
+        <section className="app__panel app__panel--deck">
+          <DeckBoard
+            cards={cards}
+            deckCounts={deckCounts}
+            onRemove={handleRemoveCard}
+            onClear={handleClearDeck}
+            apiBase={API_BASE}
+            metadata={metadata}
+          />
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,20 @@
+import { CardData, Metadata } from "./types";
+
+const defaultApiBase = "";
+const apiBase = import.meta.env.VITE_API_BASE_URL ?? defaultApiBase;
+
+async function request<T>(path: string): Promise<T> {
+  const response = await fetch(`${apiBase}${path}`);
+  if (!response.ok) {
+    throw new Error(`请求失败: ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
+export function fetchCards(): Promise<CardData[]> {
+  return request<CardData[]>("/cards");
+}
+
+export function fetchMetadata(): Promise<Metadata> {
+  return request<Metadata>("/metadata");
+}

--- a/frontend/src/components/CardTable.css
+++ b/frontend/src/components/CardTable.css
@@ -1,0 +1,114 @@
+.card-table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #ffffff;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+}
+
+.card-table thead {
+  background: linear-gradient(135deg, #1e3a8a, #312e81);
+  color: #e0e7ff;
+}
+
+.card-table th,
+.card-table td {
+  padding: 0.75rem 0.85rem;
+  border-bottom: 1px solid #e2e8f0;
+  font-size: 0.95rem;
+  vertical-align: top;
+}
+
+.card-table th {
+  text-align: left;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.card-table__row:hover {
+  background-color: #f1f5f9;
+}
+
+.card-table__thumbnail {
+  width: 80px;
+  border-radius: 0.5rem;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.16);
+}
+
+.card-table__no-image {
+  display: inline-flex;
+  width: 80px;
+  height: 112px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
+  background: #e2e8f0;
+  color: #475569;
+  font-size: 0.85rem;
+}
+
+.card-table__name {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-weight: 600;
+}
+
+.card-table__name small {
+  color: #64748b;
+  font-weight: 500;
+}
+
+.card-table__faces {
+  margin: 0.25rem 0 0;
+  padding-left: 1rem;
+  color: #475569;
+  font-size: 0.8rem;
+}
+
+.card-table__type {
+  white-space: pre-line;
+}
+
+.card-table__description {
+  max-width: 320px;
+  line-height: 1.45;
+  color: #334155;
+  position: relative;
+}
+
+.card-table__toggle {
+  margin-left: 0.5rem;
+  background: none;
+  border: none;
+  color: #2563eb;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.card-table__toggle:hover {
+  text-decoration: underline;
+}
+
+.card-table__add {
+  padding: 0.45rem 0.75rem;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+  border: none;
+  border-radius: 0.6rem;
+  cursor: pointer;
+  font-weight: 600;
+  box-shadow: 0 6px 18px rgba(37, 99, 235, 0.35);
+}
+
+.card-table__add:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.25);
+}
+
+.card-table__empty {
+  text-align: center;
+  color: #64748b;
+  padding: 2rem;
+}

--- a/frontend/src/components/CardTable.tsx
+++ b/frontend/src/components/CardTable.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { CardData } from "../types";
+import { ManaCost } from "./ManaCost";
+import "./CardTable.css";
+
+interface CardTableProps {
+  cards: CardData[];
+  onAdd: (card: CardData) => void;
+  apiBase: string;
+}
+
+export function CardTable({ cards, onAdd, apiBase }: CardTableProps) {
+  const [expandedCard, setExpandedCard] = useState<string | null>(null);
+
+  if (!cards.length) {
+    return <p className="card-table__empty">未找到符合条件的卡牌。</p>;
+  }
+
+  return (
+    <table className="card-table">
+      <thead>
+        <tr>
+          <th>卡图</th>
+          <th>名称</th>
+          <th>法术力值</th>
+          <th>类型</th>
+          <th>锁类型</th>
+          <th>法术力曲线</th>
+          <th>限制名单</th>
+          <th>描述</th>
+          <th>操作</th>
+        </tr>
+      </thead>
+      <tbody>
+        {cards.map((card) => {
+          const primaryFace = card.faces[0];
+          const secondaryFaces = card.faces.slice(1);
+          const description = primaryFace.description || "暂无描述";
+          const isExpanded = expandedCard === card.id;
+          const descriptionPreview = description.length > 120 && !isExpanded
+            ? `${description.slice(0, 120)}…`
+            : description;
+
+          const imageUrl = primaryFace.image
+            ? `${apiBase}${primaryFace.image}`
+            : undefined;
+
+          return (
+            <tr key={card.id} className="card-table__row">
+              <td>
+                {imageUrl ? (
+                  <img
+                    src={imageUrl}
+                    alt={primaryFace.chineseName}
+                    className="card-table__thumbnail"
+                  />
+                ) : (
+                  <span className="card-table__no-image">无图</span>
+                )}
+              </td>
+              <td className="card-table__name">
+                <span>{primaryFace.chineseName}</span>
+                <small>{primaryFace.englishName}</small>
+                {secondaryFaces.length > 0 && (
+                  <ul className="card-table__faces">
+                    {secondaryFaces.map((face) => (
+                      <li key={face.englishName}>
+                        {face.chineseName} / {face.englishName}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </td>
+              <td>
+                <ManaCost symbols={primaryFace.manaCost} apiBase={apiBase} />
+              </td>
+              <td className="card-table__type">{primaryFace.cardType}</td>
+              <td>{card.staxType ? card.staxType.label : "-"}</td>
+              <td>{card.manaValue}</td>
+              <td>{card.isRestricted ? "是" : "否"}</td>
+              <td className="card-table__description">
+                {descriptionPreview}
+                {description.length > 120 && (
+                  <button
+                    type="button"
+                    className="card-table__toggle"
+                    onClick={() =>
+                      setExpandedCard(isExpanded ? null : card.id)
+                    }
+                  >
+                    {isExpanded ? "收起" : "展开"}
+                  </button>
+                )}
+              </td>
+              <td>
+                <button
+                  type="button"
+                  className="card-table__add"
+                  onClick={() => onAdd(card)}
+                >
+                  加入牌本
+                </button>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/components/DeckBoard.css
+++ b/frontend/src/components/DeckBoard.css
@@ -1,0 +1,187 @@
+.deck-board {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.deck-board__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.deck-board__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.deck-board__header p {
+  margin: 0.25rem 0 0;
+  color: #475569;
+}
+
+.deck-board__clear {
+  border: none;
+  border-radius: 9999px;
+  padding: 0.45rem 1.25rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #f97316, #ef4444);
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(249, 115, 22, 0.4);
+}
+
+.deck-board__clear:disabled {
+  background: #cbd5f5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.deck-board__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem;
+}
+
+.deck-board__stats h3 {
+  margin: 0 0 0.5rem;
+}
+
+.deck-board__stats ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.deck-board__stats li {
+  display: flex;
+  justify-content: space-between;
+  background: #f8fafc;
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.deck-board__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.deck-board__grid-header,
+.deck-board__grid-row {
+  display: grid;
+  grid-template-columns: 120px repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.deck-board__grid-header {
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.deck-board__grid-label {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  color: #1e293b;
+}
+
+.deck-board__grid-cell {
+  min-height: 120px;
+  background: #f8fafc;
+  border-radius: 0.75rem;
+  padding: 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border: 1px solid #e2e8f0;
+}
+
+.deck-board__placeholder {
+  color: #cbd5f5;
+  align-self: center;
+}
+
+.deck-board__card {
+  display: grid;
+  grid-template-columns: 60px 1fr auto;
+  gap: 0.6rem;
+  align-items: center;
+  background: #fff;
+  border-radius: 0.65rem;
+  padding: 0.45rem;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+}
+
+.deck-board__card-image {
+  width: 100%;
+  border-radius: 0.5rem;
+}
+
+.deck-board__card-placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 60px;
+  height: 84px;
+  background: #e2e8f0;
+  border-radius: 0.5rem;
+  color: #475569;
+  font-size: 0.8rem;
+}
+
+.deck-board__card-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.deck-board__card-name {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.deck-board__card-info small {
+  color: #64748b;
+}
+
+.deck-board__card-count {
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.deck-board__remove {
+  border: none;
+  background: #ef4444;
+  color: #fff;
+  border-radius: 9999px;
+  padding: 0.35rem 0.65rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.deck-board__remove:hover {
+  background: #dc2626;
+}
+
+@media (max-width: 1100px) {
+  .deck-board__grid-header,
+  .deck-board__grid-row {
+    grid-template-columns: 100px repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .deck-board__grid-header,
+  .deck-board__grid-row {
+    grid-template-columns: 80px repeat(auto-fit, minmax(140px, 1fr));
+  }
+}

--- a/frontend/src/components/DeckBoard.tsx
+++ b/frontend/src/components/DeckBoard.tsx
@@ -1,0 +1,209 @@
+import { useMemo } from "react";
+import { CardData, DeckCounts, Metadata } from "../types";
+import { getCmcGroup } from "../utils/mana";
+import "./DeckBoard.css";
+
+interface DeckBoardProps {
+  cards: CardData[];
+  deckCounts: DeckCounts;
+  onRemove: (cardId: string) => void;
+  onClear: () => void;
+  apiBase: string;
+  metadata: Metadata | null;
+}
+
+interface GroupedEntry {
+  card: CardData;
+  count: number;
+}
+
+const DEFAULT_TYPES = ["生物", "神器", "结界", "其他"];
+const CMC_GROUPS = ["0", "1", "2", "3", "4", "5", "6", "7+"];
+
+export function DeckBoard({
+  cards,
+  deckCounts,
+  onRemove,
+  onClear,
+  apiBase,
+  metadata,
+}: DeckBoardProps) {
+  const cardsInDeck = useMemo(
+    () => cards.filter((card) => deckCounts[card.id]),
+    [cards, deckCounts]
+  );
+
+  const totalCards = useMemo(
+    () =>
+      cardsInDeck.reduce((acc, card) => acc + (deckCounts[card.id] ?? 0), 0),
+    [cardsInDeck, deckCounts]
+  );
+
+  const grouped = useMemo(() => {
+    const result: Record<string, Record<string, GroupedEntry[]>> = {};
+    const cardTypes = new Set<string>();
+
+    for (const card of cardsInDeck) {
+      const count = deckCounts[card.id];
+      if (!count) continue;
+      const cmcGroup = getCmcGroup(card.manaValue);
+      const cardType = card.sortCardType || "其他";
+      cardTypes.add(cardType);
+
+      if (!result[cmcGroup]) {
+        result[cmcGroup] = {};
+      }
+      if (!result[cmcGroup][cardType]) {
+        result[cmcGroup][cardType] = [];
+      }
+      result[cmcGroup][cardType].push({ card, count });
+    }
+
+    const orderedTypes = metadata?.cardTypeOrder?.length
+      ? [...metadata.cardTypeOrder]
+      : [...DEFAULT_TYPES];
+
+    for (const type of cardTypes) {
+      if (!orderedTypes.includes(type)) {
+        orderedTypes.push(type);
+      }
+    }
+
+    for (const grid of Object.values(result)) {
+      for (const entryList of Object.values(grid)) {
+        entryList.sort((a, b) =>
+          a.card.faces[0].chineseName.localeCompare(
+            b.card.faces[0].chineseName,
+            "zh-Hans"
+          )
+        );
+      }
+    }
+
+    return { grouped: result, orderedTypes };
+  }, [cardsInDeck, deckCounts, metadata]);
+
+  const manaCurve = useMemo(() => {
+    const curve: Record<string, number> = {};
+    for (const group of CMC_GROUPS) {
+      curve[group] = 0;
+    }
+    for (const card of cardsInDeck) {
+      const group = getCmcGroup(card.manaValue);
+      curve[group] = (curve[group] ?? 0) + (deckCounts[card.id] ?? 0);
+    }
+    return curve;
+  }, [cardsInDeck, deckCounts]);
+
+  const staxDistribution = useMemo(() => {
+    const distribution: Record<string, number> = {};
+    for (const card of cardsInDeck) {
+      const staxLabel = card.staxType?.label ?? "未分类";
+      distribution[staxLabel] =
+        (distribution[staxLabel] ?? 0) + (deckCounts[card.id] ?? 0);
+    }
+    return distribution;
+  }, [cardsInDeck, deckCounts]);
+
+  return (
+    <section className="deck-board">
+      <header className="deck-board__header">
+        <div>
+          <h2>牌本</h2>
+          <p>当前已选择 {totalCards} 张卡牌</p>
+        </div>
+        <button
+          type="button"
+          className="deck-board__clear"
+          onClick={onClear}
+          disabled={totalCards === 0}
+        >
+          清空牌本
+        </button>
+      </header>
+
+      <div className="deck-board__stats">
+        <div>
+          <h3>法术力曲线</h3>
+          <ul>
+            {CMC_GROUPS.map((group) => (
+              <li key={group}>
+                <span>{group}费</span>
+                <span>{manaCurve[group] ?? 0}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3>锁类型分布</h3>
+          <ul>
+            {Object.entries(staxDistribution).map(([label, count]) => (
+              <li key={label}>
+                <span>{label}</span>
+                <span>{count}</span>
+              </li>
+            ))}
+            {Object.keys(staxDistribution).length === 0 && <li>尚未选择卡牌</li>}
+          </ul>
+        </div>
+      </div>
+
+      <div className="deck-board__grid">
+        <div className="deck-board__grid-header">
+          <div>法术力值 / 类型</div>
+          {grouped.orderedTypes.map((type) => (
+            <div key={type}>{type}</div>
+          ))}
+        </div>
+        {CMC_GROUPS.map((group) => (
+          <div className="deck-board__grid-row" key={group}>
+            <div className="deck-board__grid-label">{group}费</div>
+            {grouped.orderedTypes.map((type) => {
+              const entries = grouped.grouped[group]?.[type] ?? [];
+              return (
+                <div className="deck-board__grid-cell" key={`${group}-${type}`}>
+                  {entries.map(({ card, count }) => {
+                    const face = card.faces[0];
+                    const imageUrl = face.image
+                      ? `${apiBase}${face.image}`
+                      : undefined;
+                    return (
+                      <div className="deck-board__card" key={card.id}>
+                        {imageUrl ? (
+                          <img
+                            src={imageUrl}
+                            alt={face.chineseName}
+                            className="deck-board__card-image"
+                          />
+                        ) : (
+                          <span className="deck-board__card-placeholder">无图</span>
+                        )}
+                        <div className="deck-board__card-info">
+                          <span className="deck-board__card-name">
+                            {face.chineseName}
+                          </span>
+                          <small>{face.englishName}</small>
+                          <span className="deck-board__card-count">x{count}</span>
+                        </div>
+                        <button
+                          type="button"
+                          className="deck-board__remove"
+                          onClick={() => onRemove(card.id)}
+                        >
+                          移除
+                        </button>
+                      </div>
+                    );
+                  })}
+                  {entries.length === 0 && (
+                    <span className="deck-board__placeholder">—</span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/ManaCost.css
+++ b/frontend/src/components/ManaCost.css
@@ -1,0 +1,21 @@
+.mana-cost {
+  display: inline-flex;
+  gap: 0.25rem;
+  align-items: center;
+}
+
+.mana-cost__icon {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+}
+
+.mana-cost__text {
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.mana-cost__none {
+  color: #94a3b8;
+  font-size: 0.85rem;
+}

--- a/frontend/src/components/ManaCost.tsx
+++ b/frontend/src/components/ManaCost.tsx
@@ -1,0 +1,37 @@
+import { ManaSymbol } from "../types";
+import { getManaImageUrl } from "../utils/mana";
+import "./ManaCost.css";
+
+interface ManaCostProps {
+  symbols: ManaSymbol[];
+  apiBase: string;
+}
+
+export function ManaCost({ symbols, apiBase }: ManaCostProps) {
+  if (!symbols.length) {
+    return <span className="mana-cost__none">-</span>;
+  }
+
+  return (
+    <span className="mana-cost">
+      {symbols.map((symbol, index) => {
+        const normalised = symbol.toUpperCase();
+        if (/^[A-Z0-9]{1,3}$/.test(normalised)) {
+          return (
+            <img
+              key={`${symbol}-${index}`}
+              src={getManaImageUrl(normalised, apiBase)}
+              alt={normalised}
+              className="mana-cost__icon"
+            />
+          );
+        }
+        return (
+          <span key={`${symbol}-${index}`} className="mana-cost__text">
+            {symbol}
+          </span>
+        );
+      })}
+    </span>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  font-family: "Noto Sans SC", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #1f2933;
+  background-color: #f4f6fb;
+}
+
+a {
+  color: inherit;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,35 @@
+export type ManaSymbol = string;
+
+export interface CardFace {
+  englishName: string;
+  chineseName: string;
+  image: string;
+  manaCost: ManaSymbol[];
+  cardType: string;
+  description: string;
+}
+
+export interface StaxType {
+  key: string;
+  label: string;
+}
+
+export interface CardData {
+  id: string;
+  kind: "single" | "multiface";
+  faces: CardFace[];
+  staxType: StaxType | null;
+  isRestricted: boolean;
+  legalities: Record<string, string>;
+  manaValue: number;
+  sortCardType: string;
+}
+
+export interface Metadata {
+  staxTypes: StaxType[];
+  cardTypeOrder: string[];
+}
+
+export interface DeckCounts {
+  [cardId: string]: number;
+}

--- a/frontend/src/utils/mana.ts
+++ b/frontend/src/utils/mana.ts
@@ -1,0 +1,12 @@
+import { ManaSymbol } from "../types";
+
+export function getManaImageUrl(symbol: ManaSymbol, apiBase: string): string {
+  return `${apiBase}/symbols/${symbol.toUpperCase()}.svg`;
+}
+
+export function getCmcGroup(value: number): string {
+  if (value >= 7) {
+    return "7+";
+  }
+  return String(value);
+}

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, loadEnv } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "VITE_");
+  const apiBase = env.VITE_API_BASE_URL ?? "http://localhost:8000";
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 5173,
+      host: "0.0.0.0",
+      proxy: {
+        "/cards": {
+          target: apiBase,
+          changeOrigin: true,
+        },
+        "/metadata": {
+          target: apiBase,
+          changeOrigin: true,
+        },
+        "/images": {
+          target: apiBase,
+          changeOrigin: true,
+        },
+        "/symbols": {
+          target: apiBase,
+          changeOrigin: true,
+        },
+      },
+    },
+    build: {
+      outDir: "dist",
+      sourcemap: true,
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- add a FastAPI backend that exposes card data, metadata and static resources for images and mana symbols
- scaffold a React + Vite frontend with card table, filtering and deck board views backed by the new API
- document the new workflow and update repository ignores for node builds

## Testing
- python -m compileall backend
- npm install *(fails: npm error 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68df7ad9cac4832ca1219e35f495aba3